### PR TITLE
Fix crash when freeing level texture

### DIFF
--- a/src/level.cpp
+++ b/src/level.cpp
@@ -179,6 +179,7 @@ bool Level::complete()
 
 void Level::initLevelTexture()
 { 
+    vita2d_wait_rendering_done();
     vita2d_free_texture( levelTexture );
     levelTexture = vita2d_create_empty_texture_rendertarget( 960, 544, SCE_GXM_TEXTURE_FORMAT_A8B8G8R8 );
 


### PR DESCRIPTION
There is currently a crash occurring when the level texture is freed.

## How to reproduce

1. Complete a level
2. Select **Restart** from the menu
3. Complete the level again
4. Select **Restart** from the menu

At this point, the game crashes 90% of the time from my observations.
If not, complete & restart the level one more time.

The crash causes either:
* Freezing of the console, requiring a hard reset (30s power off)
* An actual "An error occurred, the console will now shut down"

## Demonstration

https://imgur.com/a/b9tNk3s

Notice: the second **Restart** causes the game to freeze. I am not able to do anything with the console after that. A hard reset is necessary

## What causes this

I believe this was introduced in 039c7cd034c48, and is related to the discussion [here](https://github.com/xerpi/libvita2d/issues/28). `vita2d_free_texture` is called while the GPU is still (possibly) using the texture.

## Solution

As recommended by @xerpi in [this comment](https://github.com/xerpi/libvita2d/issues/28#issuecomment-249369937), I added `vita2d_wait_rendering_done()` before the `vita2d_free_texture` call.

This solves the issue for me.

I am not very familiar with vita2d (or anything Vita for that matter), there may be a better explanation and/or a better way to solve this.